### PR TITLE
Minor patches for client teleporting with the _MoveForward command

### DIFF
--- a/Commander/Builtin.py
+++ b/Commander/Builtin.py
@@ -24,6 +24,14 @@ ClientTeleporting: ModMenu.Options.Spinner = ModMenu.Options.Spinner(
     Choices=["Allow", "With Host", "None"],
     StartingValue="Allow"
 )
+ClientTeleportingDistance: ModMenu.Options.Slider = ModMenu.Options.Slider(
+    Caption="Client Teleporting Distance",
+    Description="Specifies the distance the user can teleport, using the 'Move Forward' command.",
+    StartingValue=250,
+    MinValue=250,
+    MaxValue=25000,
+    Increment=250
+)
 ClientSpeedPermissions: ModMenu.Options.Boolean = ModMenu.Options.Boolean(
     Caption="Client Speed Permissions",
     Description="Should clients in multiplayer be allowed to modify the speed of the game.",
@@ -32,7 +40,7 @@ ClientSpeedPermissions: ModMenu.Options.Boolean = ModMenu.Options.Boolean(
 
 
 Options: Sequence[ModMenu.Options.Base] = (
-    Positions, DamageNumbers, ClientTeleporting, ClientSpeedPermissions
+    Positions, DamageNumbers, ClientTeleporting, ClientTeleportingDistance, ClientSpeedPermissions
 )
 
 def PC():
@@ -209,9 +217,11 @@ def _MoveForward():
     pitch = position["Pitch"] / 65535 * math.tau
     yaw   = position["Yaw"  ] / 65535 * math.tau
 
-    position["Z"] += math.sin(pitch) * 250
-    position["X"] += math.cos(yaw) * math.cos(pitch) * 250
-    position["Y"] += math.sin(yaw) * math.cos(pitch) * 250
+    distance = ClientTeleportingDistance.CurrentValue
+
+    position["Z"] += math.sin(pitch) * distance
+    position["X"] += math.cos(yaw) * math.cos(pitch) * distance
+    position["Y"] += math.sin(yaw) * math.cos(pitch) * distance
 
     _StopPlayer(PC())
 

--- a/Commander/Builtin.py
+++ b/Commander/Builtin.py
@@ -137,7 +137,7 @@ def _ToggleDamageNumbers():
 
 
 _Position = 0
-_MaxPositions = 5
+_MaxPositions = 6
 def _DefaultPositions():
     global _MaxPositions
     return [None] * _MaxPositions
@@ -157,11 +157,6 @@ def _GetPosition(PC):
     }
 
 
-def _StopPlayer(PC):
-    PlayerPawn = PC.Pawn
-    PlayerPawn.Velocity = 0, 0, 0
-
-
 def ApplyPosition(PC, position):
     location = position["X"], position["Y"], position["Z"]
     rotation = position["Pitch"], position["Yaw"], 0
@@ -175,13 +170,22 @@ def ApplyPosition(PC, position):
         pawn.Mesh.SetRBRotation(rotation)
     PC.ClientSetRotation(rotation)
 
-    _StopPlayer(PC())
+    PlayerPawn = PC.Pawn
+    PlayerPawn.Velocity = 0, 0, 0
+
+
+def _FixPositionsArray(positions):
+    global _MaxPositions
+    if len(positions) < _MaxPositions:
+        positions = positions + ([None] * (_MaxPositions - len(positions)))
+    return positions
 
 
 def _SavePosition():
     mapName = GetEngine().GetCurrentWorldInfo().GetMapName(True)
 
     positions = Positions.CurrentValue.get(mapName, _DefaultPositions())
+    positions = _FixPositionsArray(positions)
     positions[_Position] = _GetPosition(PC())
 
     Positions.CurrentValue[mapName] = positions
@@ -193,7 +197,10 @@ def _SavePosition():
 def _RestorePosition():
     mapName = GetEngine().GetCurrentWorldInfo().GetMapName(True)
 
-    position = Positions.CurrentValue.get(mapName, _DefaultPositions())[_Position]
+    positions = Positions.CurrentValue.get(mapName, _DefaultPositions())
+    positions = _FixPositionsArray(positions)
+    position = positions[_Position]
+
     if position is None:
         Popup(f"Position {_Position + 1} Not Saved")
 

--- a/Commander/Builtin.py
+++ b/Commander/Builtin.py
@@ -144,7 +144,7 @@ def _DefaultPositions():
 
 def _SelectPosition():
     global _Position, _MaxPositions
-    _Position =  _Position + 1 % _MaxPositions
+    _Position =  (_Position + 1) % _MaxPositions
     Popup(f"Selected Position {_Position + 1}")
 
 

--- a/Commander/Builtin.py
+++ b/Commander/Builtin.py
@@ -150,6 +150,11 @@ def _GetPosition(PC):
     }
 
 
+def _StopPlayer(PC):
+    PlayerPawn = PC.Pawn
+    PlayerPawn.Velocity = 0, 0, 0
+
+
 def ApplyPosition(PC, position):
     location = position["X"], position["Y"], position["Z"]
     rotation = position["Pitch"], position["Yaw"], 0
@@ -207,6 +212,8 @@ def _MoveForward():
     position["Z"] += math.sin(pitch) * 250
     position["X"] += math.cos(yaw) * math.cos(pitch) * 250
     position["Y"] += math.sin(yaw) * math.cos(pitch) * 250
+
+    _StopPlayer(PC())
 
     if _IsClient():
         Commander.Instance.ServerRequestPosition(position, name=None)

--- a/Commander/Commander.py
+++ b/Commander/Commander.py
@@ -62,7 +62,7 @@ def CompileCustomCommand(command: str) -> Callable[[], None]:
 
 class Commander(ModMenu.SDKMod):
     Name: str = "Commander"
-    Version: str = "2.5"
+    Version: str = "2.6"
     Description: str = "Perform various actions in game using key bindings."
     Author: str = "mopioid"
     Types: ModMenu.ModTypes = ModMenu.ModTypes.Gameplay


### PR DESCRIPTION
-  Added a slider to change the distance the player can teleport with the MoveForward.
- Removed the player's velocity for the MoveForward to keep from constantly accelerating. Useful for if the player falls off the map of wants to teleport upwards.